### PR TITLE
Fix/1.0 tk12255 make display conditions more readable and show links on agenda events

### DIFF
--- a/class/actions_related.class.php
+++ b/class/actions_related.class.php
@@ -83,14 +83,14 @@ class ActionsRelated
                 else if($type=='facture_fournisseur') $type= 'invoice_supplier';
                 else if($type=='commande_fournisseur') $type='order_supplier';
 
-                $object->db->begin(); //escape bad recurssive inclusion 
+                $object->db->begin(); //escape bad recurssive inclusion
                 //TODO find a way to report this to user
-                
+
                 $res = $object->add_object_linked( $type , GETPOST('id_related_object') );
 				$object->fetchObjectLinked();
-               
+
              	$object->db->commit();
-               	
+
                 if(empty($res)) {
                 	setEventMessage($langs->trans('RelationCantBeAdded' ),'errors');
                 }
@@ -161,8 +161,21 @@ class ActionsRelated
 							$class = 'pair';
 
 							foreach($object->linkedObjectsIds as $objecttype => &$TSubIdObject) {
-								//var_dump($objecttype);
-								if(isset( $object->linkedObjects[$objecttype] ) && $objecttype!='societe' && $objecttype!='contratabonnement' && $objecttype!='product' && $object->element!='project' && !($object->element=='societe' && ($objecttype=='facture' || $objecttype=='propal' || $objecttype=='commande'))) continue; // on affiche ici que les objects non géré en natif
+								$showThisLink = false;
+								// conditions pour afficher le lien:
+								// si l'objet lié est un tiers, un contrat/abonnement, un produit ou un projet
+								if (in_array($objecttype, array('societe', 'contratabonnement', 'product', 'project')))
+									$showThisLink = true;
+								// si on est sur une fiche tiers et que l'objet lié est une facture, propale ou commande
+								elseif ($object->element == 'societe'
+										&& in_array($objecttype, array('facture', 'propal', 'commande')))
+									$showThisLink = true;
+								// si on est sur une fiche événement
+								elseif (in_array($object->element, array('action')))
+									$showThisLink = true;
+
+								// $showThisLink doit être false si l'objet est géré en natif
+								if (!$showThisLink) continue;
 
 								foreach($TSubIdObject as $id_object) {
 									$date_create = 0;
@@ -247,7 +260,7 @@ class ActionsRelated
 
 									$Tids = TRequeteCore::get_id_from_what_you_want($PDOdb, MAIN_DB_PREFIX."element_element",array('fk_source'=>$id_object,'fk_target'=>$object->id,'sourcetype'=>$objecttype,'targettype'=>$object->element));
 									if(empty($Tids)) $Tids = TRequeteCore::get_id_from_what_you_want($PDOdb, MAIN_DB_PREFIX."element_element",array('fk_source'=>$object->id,'fk_target'=>$id_object,'sourcetype'=>$object->element,'targettype'=>$objecttype));
-									
+
 									?>
 									<tr class="<?php echo $class ?>">
 										<td><?php echo $link; ?></td>

--- a/class/actions_related.class.php
+++ b/class/actions_related.class.php
@@ -173,6 +173,9 @@ class ActionsRelated
 								// si on est sur une fiche événement
 								elseif (in_array($object->element, array('action')))
 									$showThisLink = true;
+								// si l'objet lié n'est pas chargé
+								elseif (!isset( $object->linkedObjects[$objecttype] ))
+									$showThisLink = true;
 
 								// $showThisLink doit être false si l'objet est géré en natif
 								if (!$showThisLink) continue;

--- a/class/actions_related.class.php
+++ b/class/actions_related.class.php
@@ -132,8 +132,20 @@ class ActionsRelated
 				}
 			}
 			else {
-			    //var_dump($object);
+				// Ce bazar vient de fetchObjectLinked qui s'autocensure pour les types d'objet dont le nom ne
+				// correspond pas à un module activé (sauf certains qui ont un traitement spécial).
+				$TFakeModule = array();
+				foreach (array ('event' => 'agenda', ) as $objectname => $realmodulename) {
+					if (empty($conf->{$objectname}->enabled)         // le "faux" module n'est pas activé
+						&& !empty($conf->{$realmodulename}->enabled) // le vrai module correspondant doit être activé
+					) {
+						$TFakeModule[] = $objectname;
+						$conf->{$objectname} = new stdClass();
+						$conf->{$objectname}->enabled = true;
+					}
+				}
 				if (empty($object->linkedObjects)) $object->fetchObjectLinked();
+				foreach ($TFakeModule as $objectname) unset($conf->{$objectname});
 			}
 		//var_dump($object->linkedObjectsIds);
 		 	?>
@@ -164,7 +176,7 @@ class ActionsRelated
 								$showThisLink = false;
 								// conditions pour afficher le lien:
 								// si l'objet lié est un tiers, un contrat/abonnement, un produit ou un projet
-								if (in_array($objecttype, array('societe', 'contratabonnement', 'product', 'project')))
+								if (in_array($objecttype, array('societe', 'contratabonnement', 'product', 'project', 'action')))
 									$showThisLink = true;
 								// si on est sur une fiche tiers et que l'objet lié est une facture, propale ou commande
 								elseif ($object->element == 'societe'


### PR DESCRIPTION
# FIX
*Related* repose sur les liens element_element, mais actuellement, il est possible de créer des liens que Dolibarr n'affichera pas (notamment les liens vers des événements agenda), ce qui est problématique.

Dans le code du module, la condition qui détermine si un lien doit être affiché par le module ou si Dolibarr le gère en natif était très longue et difficilement lisible, donc je l'ai réécrite en plusieurs petits morceaux plus faciles à comprendre. J'ai aussi ajouté les liens événements à la liste des éléments à afficher par le module et j'ai dû contourner le souci de `fetchObjectLinked` qui s'auto-censure lorsque le type d'élément ne correspond pas à un nom de module actif.




----

*Related* works by creating new element_element links, but as it stands, it enables the user to create links that it cannot display (e.g. links to agenda events). There was a very long and hard to read condition to determine whether an element_element link needs to be shown by the module or whether it is already handled by Dolibarr.

This PR breaks down this long condition into smaller and easier-to-read conditions and adds link to agenda events to the list of elements that should be shown by the module.

It also fixes a problem with `fetchObjectLinked`'s self-censorship when an element type doesn't match an active module name (element_element objects to or from agenda events were never fetched).