### PR TITLE
Update module version and remove deprecated 'asset' support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,8 @@
 
 
 
-## Release 1.10
+## Release 1.10
+- FIX DA026311 : removed references to the deprecated 'asset' and 'ordre_fabrication' elements across the codebase. This includes adjustments to class mappings, known elements, and checks for deprecated modules  - *18/04/2025* - 1.10.2
 - FIX : Compat v21   - *10/12/2024* - 1.10.1
 
 - NEW : DA025244 - Ajout des contextes hook webmodulecard, webinstancecard, webhostcard pour elements particuliers liées - *23/08/2024* - 1.10.0

--- a/class/actions_related.class.php
+++ b/class/actions_related.class.php
@@ -62,8 +62,6 @@ class ActionsRelated extends \related\RetroCompatCommonHookActions
 		'action' => '/comm/action/class/actioncomm.class.php',
 		'project' => '/projet/class/project.class.php',
 		'projet' => '/projet/class/project.class.php',
-		'ordre_fabrication' => '/ordre_fabrication_asset.class.php',
-		'asset' => '/asset/class/asset.class.php',
 		'assetatm' => '/assetatm/class/asset.class.php',
 		'contratabonnement' => '/contrat/class/contrat.class.php',
 		'ticket' => '/ticket/class/ticket.class.php',
@@ -77,8 +75,6 @@ class ActionsRelated extends \related\RetroCompatCommonHookActions
 	const CLASSNAMEMAP = array(
 		'event' => 'ActionComm',
 		'action' => 'ActionComm',
-		'ordre_fabrication' => 'TAssetOf',
-		'asset' => 'TAsset',
 		'assetatm' => 'TAsset',
 		'contratabonnement' => 'Contrat',
 		'projet' => 'Project',
@@ -94,8 +90,7 @@ class ActionsRelated extends \related\RetroCompatCommonHookActions
 	);
 
 	const IS_ABRICOT = array(
-		'asset',
-		'assetatm',
+		'assetatm'
 	);
 
 	/**
@@ -128,7 +123,6 @@ class ActionsRelated extends \related\RetroCompatCommonHookActions
 	 */
 	public $knownElements = array(
 		'project',
-		'asset',
 		'contratabonnement',
 		'projet',
 		'fichinter',

--- a/core/modules/modRelated.class.php
+++ b/core/modules/modRelated.class.php
@@ -60,7 +60,7 @@ class modRelated extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Links elements together";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.10.1';
+		$this->version = '1.10.2';
 		// Url to the file with your last numberversion of this module
 		require_once __DIR__ . '/../../class/techatm.class.php';
 		$this->url_last_version = \related\TechATM::getLastModuleVersionUrl($this);

--- a/script/interface.php
+++ b/script/interface.php
@@ -39,14 +39,6 @@ function _search($keyword) {
 		'ticket',
 	);
 
-	if(isModEnabled("of")) {
-		$TType[] = 'ordre_fabrication';
-	}
-
-    if(isModEnabled("asset")) {
-        $TType[] = 'asset';
-    }
-
     if(isModEnabled("assetatm")) {
         $TType[] = 'assetatm';
     }
@@ -188,18 +180,6 @@ function _search_type($type, $keyword) {
     	$ref_field='ref';
     	$join_to_soc = true;
     }
-	else if(isModEnabled("of") && $type == 'ordre_fabrication') {
-		$table=MAIN_DB_PREFIX.'assetOf';
-        $objname='TAssetOf';
-        $ref_field='numero';
-
-	}
-	else if(isModEnabled("asset") && $type == 'asset') {
-		$table=MAIN_DB_PREFIX.'asset';
-        $objname='TAsset';
-        $ref_field='serial_number';
-        $id_field='rowid';
-	}
 	else if(isModEnabled("assetatm") && $type == 'assetatm') {
 		$table=MAIN_DB_PREFIX.'assetatm';
 		$objname='TAsset';


### PR DESCRIPTION
Updated the module version to 1.10.2 and removed references to the deprecated 'asset' and 'ordre_fabrication' elements across the codebase. This includes adjustments to class mappings, known elements, and checks for deprecated modules.